### PR TITLE
Fix email sending and add Google OAuth2 support with Gmail transport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "crypto-js": "^4.1.1",
         "dotenv": "^16.0.1",
         "express": "^4.18.1",
+        "gmail-nodemailer-transport": "^3.0.2",
         "googleapis": "^148.0.0",
         "hmacsha1": "^1.0.0",
         "joi": "^17.6.0",
@@ -1649,6 +1650,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gmail-nodemailer-transport": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gmail-nodemailer-transport/-/gmail-nodemailer-transport-3.0.2.tgz",
+      "integrity": "sha512-6Eaa2EiRMi7XtbIbyvUCjfHdNjqGHFX1K3COzCmKXFGSeLcYXCIA1xk13ZVfCezUjrRhb25hGrRUlU/qLsNJgQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "nodemailer": ">=4.0.0"
       }
     },
     "node_modules/google-auth-library": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "crypto-js": "^4.1.1",
     "dotenv": "^16.0.1",
     "express": "^4.18.1",
+    "gmail-nodemailer-transport": "^3.0.2",
     "googleapis": "^148.0.0",
     "hmacsha1": "^1.0.0",
     "joi": "^17.6.0",

--- a/src/clients/nodemailer.ts
+++ b/src/clients/nodemailer.ts
@@ -1,32 +1,20 @@
 import nodemailer from 'nodemailer';
 import * as dotEnv from 'dotenv';
-import { google } from 'googleapis';
+import GmailTransport from 'gmail-nodemailer-transport';
 dotEnv.config();
 
-const CLIENT_ID = process.env.CLIENT_ID
-const CLIENT_SECRET = process.env.CLIENT_SECRET;
-const REFRESH_TOKEN = process.env.REFRESH_TOKEN;
-const REDIRECT_URI = process.env.REDIRECT_URI;
-
-const oauth2Client = new google.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-oauth2Client.setCredentials({ refresh_token: REFRESH_TOKEN });
-
 export const mailerClient = async () => {
-  const accessToken = await oauth2Client.getAccessToken();
 
-  const transport = nodemailer.createTransport({
-    service: 'gmail',
+  const transporter = nodemailer.createTransport(new GmailTransport({
+    userId: process.env.MAIL_USER,               // your Gmail address
     auth: {
-      type: 'OAuth2',
-      user: process.env.MAIL_USER,
-      clientId: CLIENT_ID,
-      clientSecret: CLIENT_SECRET,
-      refreshToken: REFRESH_TOKEN,
-      accessToken: accessToken.token,
-    },
-  } as any);
+        clientId: process.env.CLIENT_ID,         
+        clientSecret: process.env.CLIENT_SECRET,
+        refreshToken: process.env.REFRESH_TOKEN,
+      }
+  }));
 
-  return transport;
+  return transporter;
 };
 
 /**host: 'smtp.xcelapp.com',


### PR DESCRIPTION
Enhance email functionality by integrating `gmail-nodemailer-transport` for simplified Gmail support and fixing existing email sending issues.